### PR TITLE
Add support for disabling referral chasing

### DIFF
--- a/whois.go
+++ b/whois.go
@@ -9,100 +9,95 @@
 
 package whois
 
-
 import (
-    "fmt"
-    "net"
-    "time"
-    "strings"
-    "io/ioutil"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"strings"
+	"time"
 )
-
 
 const (
-    WHOIS_DOMAIN = "whois-servers.net"
-    WHOIS_PORT = "43"
+	WHOIS_DOMAIN = "whois-servers.net"
+	WHOIS_PORT   = "43"
 )
 
-
 func Version() string {
-    return "0.5.0"
+	return "0.5.0"
 }
-
 
 func Author() string {
-    return "[Li Kexian](https://www.likexian.com/)"
+	return "[Li Kexian](https://www.likexian.com/)"
 }
-
 
 func License() string {
-    return "Apache License, Version 2.0"
+	return "Apache License, Version 2.0"
 }
 
+func Whois(domain string, chaseReferal bool, servers ...string) (result string, err error) {
+	domain = strings.Trim(strings.Trim(domain, " "), ".")
+	if domain == "" {
+		err = fmt.Errorf("Domain is empty")
+		return
+	}
 
-func Whois(domain string, servers ...string) (result string, err error) {
-    domain = strings.Trim(strings.Trim(domain, " "), ".")
-    if domain == "" {
-        err = fmt.Errorf("Domain is empty")
-        return
-    }
+	result, err = query(domain, servers...)
+	if err != nil {
+		return
+	}
 
-    result, err = query(domain, servers...)
-    if err != nil {
-        return
-    }
+	start := strings.Index(result, "Registrar WHOIS Server:")
+	if start == -1 {
+		return
+	}
 
-    start := strings.Index(result, "Registrar WHOIS Server:")
-    if start == -1 {
-        return
-    }
+	if chaseReferal {
+		start += 23
+		end := strings.Index(result[start:], "\n")
+		server := strings.Trim(strings.Replace(result[start:start+end], "\r", "", -1), " ")
+		if server == "" {
+			return
+		}
+		var tmp_result string
+		tmp_result, err = query(domain, server)
+		if err != nil {
+			return
+		}
 
-    start += 23
-    end := strings.Index(result[start:], "\n")
-    server := strings.Trim(strings.Replace(result[start:start + end], "\r", "", -1), " ")
-    if server == "" {
-        return
-    }
+		result += tmp_result
+	}
 
-    tmp_result, err := query(domain, server)
-    if err != nil {
-        return
-    }
-
-    result += tmp_result
-
-    return
+	return
 }
-
 
 func query(domain string, servers ...string) (result string, err error) {
-    var server string
-    if len(servers) == 0 || servers[0] == "" {
-        domains := strings.Split(domain, ".")
-        if len(domains) < 2 {
-            err = fmt.Errorf("Domain %s is invalid", domain)
-            return
-        }
-        server = domains[len(domains) - 1] + "." + WHOIS_DOMAIN
-    } else {
-        server = servers[0]
-    }
+	var server string
+	if len(servers) == 0 || servers[0] == "" {
+		domains := strings.Split(domain, ".")
+		if len(domains) < 2 {
+			err = fmt.Errorf("Domain %s is invalid", domain)
+			return
+		}
+		server = domains[len(domains)-1] + "." + WHOIS_DOMAIN
+	} else {
+		server = servers[0]
+	}
 
-    conn, e := net.DialTimeout("tcp", net.JoinHostPort(server, WHOIS_PORT), time.Second * 30)
-    if e != nil {
-        err = e
-        return
-    }
+	conn, e := net.DialTimeout("tcp", net.JoinHostPort(server, WHOIS_PORT), time.Second*30)
+	if e != nil {
+		err = e
+		return
+	}
 
-    defer conn.Close()
-    conn.Write([]byte(domain + "\r\n"))
-    buffer, e := ioutil.ReadAll(conn)
-    if e != nil {
-        err = e
-        return
-    }
+	defer conn.Close()
+	conn.Write([]byte(domain + "\r\n"))
+	buffer, e := ioutil.ReadAll(conn)
+	if e != nil {
+		err = e
+		return
+	}
 
-    result = string(buffer)
+	result = string(buffer)
 
-    return
+	return
 }

--- a/whois_test.go
+++ b/whois_test.go
@@ -9,31 +9,30 @@
 
 package whois
 
-
 import (
-    "testing"
-    "github.com/bmizerany/assert"
+	"testing"
+
+	"github.com/bmizerany/assert"
 )
 
-
 func TestWhois(t *testing.T) {
-    result, err := Whois("likexian")
-    assert.NotEqual(t, nil, err)
-    assert.Equal(t, "", result)
+	result, err := Whois("likexian", true)
+	assert.NotEqual(t, nil, err)
+	assert.Equal(t, "", result)
 
-    result, err = Whois("likexian.com")
-    assert.Equal(t, nil, err)
-    assert.NotEqual(t, "", result)
+	result, err = Whois("likexian.com", true)
+	assert.Equal(t, nil, err)
+	assert.NotEqual(t, "", result)
 
-    result, err = Whois("likexian.com", "127.0.0.1")
-    assert.NotEqual(t, nil, err)
-    assert.Equal(t, "", result)
+	result, err = Whois("likexian.com", true, "127.0.0.1")
+	assert.NotEqual(t, nil, err)
+	assert.Equal(t, "", result)
 
-    result, err = Whois("likexian.com", "com.whois-servers.net")
-    assert.Equal(t, nil, err)
-    assert.NotEqual(t, "", result)
+	result, err = Whois("likexian.com", true, "com.whois-servers.net")
+	assert.Equal(t, nil, err)
+	assert.NotEqual(t, "", result)
 
-    result, err = Whois("likexian.com.cn")
-    assert.Equal(t, nil, err)
-    assert.NotEqual(t, "", result)
+	result, err = Whois("likexian.com.cn", false)
+	assert.Equal(t, nil, err)
+	assert.NotEqual(t, "", result)
 }


### PR DESCRIPTION
Add an option to allow disabling of referral chasing.

This is useful in two use cases.

1. You are only interested in the registration info and dates not the owner.
2. Some whois servers return inconsistent information when the referral server is queried. An example is whois.namebright.com the update dates there are incorrect but correct in the brief info returned from com.whois-servers.net
